### PR TITLE
Adding DPDist and DeepFit papers (ECCV 2020)

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,6 +442,8 @@ Statistics: :fire: code is available & stars >= 100 &emsp;|&emsp; :star: citatio
 - 
 - [[ECCV](https://arxiv.org/pdf/1912.12098.pdf)] Quaternion Equivariant Capsule Networks for 3D Point Clouds. [__`cls.`__]
 - [[ECCV](https://arxiv.org/pdf/2007.10985.pdf)] PointContrast: Unsupervised Pre-training for 3D Point Cloud Understanding. [__`cls.`__ __`seg.`__ __`det.`__]
+- [[ECCV](https://arxiv.org/abs/2003.10826)] DeepFit: 3D Surface Fitting via Neural Network Weighted Least Squares. [[code](https://github.com/sitzikbs/DeepFit)] [__`oth.`__]
+- [[ECCV](https://arxiv.org/abs/2004.11784v2)] DPDist: Comparing Point Clouds Using Deep Point Cloud Distance. [[code](https://github.com/dahliau/DPDist)] [__`oth.`__]
 <h1> 
 
 ```diff


### PR DESCRIPTION
Hi,
Please add my paper DPDist and my college paper DeepFit both from the last ECCV 2020.
DPDist is a new method for comparing between point clouds using local implicit neural functions.
I've updated the links to the paper and code.
Thanks in advance,
Dahlia
